### PR TITLE
fix(mariadb): Use sudo for initial MariaDB security script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -264,7 +264,8 @@ secure_mariadb() {
     local db_root_password=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 20)
 
     # Non-interactive security script
-    mysql -u root <<-EOF
+    # Use sudo to ensure it works with socket authentication
+    sudo mysql -u root <<-EOF
 -- Set root password
 ALTER USER 'root'@'localhost' IDENTIFIED BY '${db_root_password}';
 -- Remove anonymous users


### PR DESCRIPTION
On modern Debian-based systems, MariaDB defaults to using the `unix_socket` authentication plugin for the `root` user. This prevents the `root` user from logging in with a password and instead requires the command to be run by the system's `root` user.

The `secure_mariadb` function was failing because it was running `mysql -u root` without `sudo`, resulting in an "Access denied" error.

This commit fixes the issue by adding `sudo` to the `mysql` command in the `secure_mariadb` function, allowing the script to correctly authenticate and secure the MariaDB installation.