### PR TITLE
Fix: Correct Dovecot configuration for Postfix auth socket

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -530,12 +530,12 @@ setup_mail_server_logic() {
 set /files/etc/dovecot/conf.d/10-mail.conf/mail_location "maildir:~/Maildir"
 set /files/etc/dovecot/conf.d/10-auth.conf/auth_mechanisms "plain login"
 
-# Set up authentication socket for Postfix
-set /files/etc/dovecot/conf.d/10-master.conf/service[last()+1] "unix_listener"
-set /files/etc/dovecot/conf.d/10-master.conf/service[last()]/name "/var/spool/postfix/private/auth"
-set /files/etc/dovecot/conf.d/10-master.conf/service[last()]/mode "0660"
-set /files/etc/dovecot/conf.d/10-master.conf/service[last()]/user "postfix"
-set /files/etc/dovecot/conf.d/10-master.conf/service[last()]/group "postfix"
+# Set up authentication socket for Postfix inside the 'auth' service
+defvar auth_service /files/etc/dovecot/conf.d/10-master.conf/service[name='auth']
+set \$auth_service/unix_listener[last()+1] "/var/spool/postfix/private/auth"
+set \$auth_service/unix_listener[last()]/mode "0660"
+set \$auth_service/unix_listener[last()]/user "postfix"
+set \$auth_service/unix_listener[last()]/group "postfix"
 
 # Configure SSL
 set /files/etc/dovecot/conf.d/10-ssl.conf/ssl "required"


### PR DESCRIPTION
The previous augtool commands were incorrectly creating a new top-level 'service' block for the Postfix unix_listener, which resulted in a malformed configuration and caused the Dovecot service to fail on startup.

This commit corrects the augtool commands to locate the existing 'service' block with the name 'auth' and properly adds the 'unix_listener' within it. This ensures the generated configuration is valid and allows Dovecot to start successfully with the Postfix SASL authentication socket enabled.